### PR TITLE
Move class initialization from application to window

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -8,8 +8,8 @@ use gtk::{gdk, gio, glib};
 use log::{debug, info};
 use once_cell::sync::OnceCell;
 
+use crate::config;
 use crate::window::Window;
-use crate::{config, view};
 
 mod imp {
     use super::*;
@@ -24,14 +24,6 @@ mod imp {
         const NAME: &'static str = "Application";
         type Type = super::Application;
         type ParentType = gtk::Application;
-
-        fn class_init(_: &mut Self::Class) {
-            // Initialize all classes here
-            view::CheckServicePage::static_type();
-            view::ImageRowSimple::static_type();
-            view::ImagesPanel::static_type();
-            view::StartServicePage::static_type();
-        }
     }
 
     impl ObjectImpl for Application {}

--- a/src/window.rs
+++ b/src/window.rs
@@ -47,6 +47,12 @@ mod imp {
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
 
+            // Initialize all classes here
+            view::CheckServicePage::static_type();
+            view::ImageRowSimple::static_type();
+            view::ImagesPanel::static_type();
+            view::StartServicePage::static_type();
+
             klass.install_property_action("images.show-intermediates", "show-intermediate-images");
             klass.install_action("images.prune-unused", None, move |widget, _, _| {
                 widget.imp().images_panel.show_prune_dialog();


### PR DESCRIPTION
We don't need to initialize the classes so early. It is enough if we do
this in the window. This also prevents the classes from being initial-
ized unnecessarily when the application should only output the version
on the command line.