### PR TITLE
Prevent list boxes from being cut off

### DIFF
--- a/data/resources/ui/containers-panel.ui
+++ b/data/resources/ui/containers-panel.ui
@@ -75,7 +75,7 @@
                 <!-- List of containers -->
                 <child>
                   <object class="AdwPreferencesPage">
-                    <property name="valign">start</property>
+                    <property name="vexpand">True</property>
 
                     <child>
                       <object class="AdwPreferencesGroup" id="containers_group">

--- a/data/resources/ui/images-panel.ui
+++ b/data/resources/ui/images-panel.ui
@@ -77,7 +77,7 @@
                 <!-- List of images -->
                 <child>
                   <object class="AdwPreferencesPage">
-                    <property name="valign">start</property>
+                    <property name="vexpand">True</property>
 
                     <child>
                       <object class="AdwPreferencesGroup" id="images_group">


### PR DESCRIPTION
Replacing the property `valign=start` with `vexpand=True` on the
`AdwPreferencesPages` should do the trick.

fixes #80