### PR TITLE
image-list: fix progress bar behaviour on error

### DIFF
--- a/src/model/image_list.rs
+++ b/src/model/image_list.rs
@@ -304,14 +304,13 @@ impl ImageList {
 
                                             obj.image_added(&image);
                                             obj.items_changed(obj.len() - 1, 0, 1);
-
-                                            obj.set_fetched(obj.fetched() + 1);
                                         }
                                         Err(e) => {
                                             log::error!("Error on inspecting image: {}", e);
                                             err_op(err);
                                         }
                                     }
+                                    obj.set_fetched(obj.fetched() + 1);
                                 })
                             );
                         });


### PR DESCRIPTION
Complete the progress bar, even if an error is encountered inspecting an image. See image for current behaviour.

![image](https://user-images.githubusercontent.com/15961647/159142728-b2a57b28-7799-4636-b2b6-73bfcf08757b.png)

I can't build and test locally because linking against libadwaita fails for some reason

```
= note: /usr/bin/ld: /home/jakob/projects/symphony/_build/src/release/deps/liblibadwaita-34cf6e2659e056e2.rlib(libadwaita-34cf6e2659e056e2.libadwaita.da37e230-cgu.8.rcgu.o): in function `libadwaita::auto::toast_overlay::ToastOverlay::add_toast':
          libadwaita.da37e230-cgu.8:(.text._ZN10libadwaita4auto13toast_overlay12ToastOverlay9add_toast17h5f6dc60112fffc38E+0x16): undefined reference to `adw_toast_overlay_add_toast'
          /usr/bin/ld: /home/jakob/projects/symphony/_build/src/release/deps/liblibadwaita-34cf6e2659e056e2.rlib(libadwaita-34cf6e2659e056e2.libadwaita.da37e230-cgu.8.rcgu.o): in function `<libadwaita::auto::toast_overlay::ToastOverlay as glib::types::StaticType>::static_type':
          libadwaita.da37e230-cgu.8:(.text._ZN89_$LT$libadwaita..auto..toast_overlay..ToastOverlay$u20$as$u20$glib..types..StaticType$GT$11static_type17hfbb72adbed41a61eE+0x2): undefined reference to `adw_toast_overlay_get_type'
          /usr/bin/ld: /home/jakob/projects/symphony/_build/src/release/deps/liblibadwaita-34cf6e2659e056e2.rlib(libadwaita-34cf6e2659e056e2.libadwaita.da37e230-cgu.9.rcgu.o): in function `glib::object::Object::new':
          libadwaita.da37e230-cgu.9:(.text._ZN4glib6object6Object3new17hecf886c6dbd98453E+0x16): undefined reference to `adw_toast_get_type'
          /usr/bin/ld: libadwaita.da37e230-cgu.9:(.text._ZN4glib6object6Object3new17hecf886c6dbd98453E+0x8b): undefined reference to `adw_toast_get_type'
          /usr/bin/ld: /home/jakob/projects/symphony/_build/src/release/deps/liblibadwaita-34cf6e2659e056e2.rlib(libadwaita-34cf6e2659e056e2.libadwaita.da37e230-cgu.11.rcgu.o): in function `<libadwaita::auto::enums::ToastPriority as glib::value::ToValue>::to_value':
          libadwaita.da37e230-cgu.11:(.text._ZN79_$LT$libadwaita..auto..enums..ToastPriority$u20$as$u20$glib..value..ToValue$GT$8to_value17h7ed09eb06a9306d1E+0xc): undefined reference to `adw_toast_priority_get_type'
          /usr/bin/ld: /home/jakob/projects/symphony/_build/src/release/deps/liblibadwaita-34cf6e2659e056e2.rlib(libadwaita-34cf6e2659e056e2.libadwaita.da37e230-cgu.11.rcgu.o): in function `<libadwaita::auto::enums::ToastPriority as glib::value::ToValue>::value_type':
          libadwaita.da37e230-cgu.11:(.text._ZN79_$LT$libadwaita..auto..enums..ToastPriority$u20$as$u20$glib..value..ToValue$GT$10value_type17h2b55be2bb403b14aE+0x2): undefined reference to `adw_toast_priority_get_type'
          collect2: error: ld returned 1 exit status
```

```bash
$ dnf list installed "libadwaita-*"
Installed Packages
libadwaita-demo.noarch                 1.0.0-0.6.alpha.4.fc35                @updates
libadwaita-devel.x86_64                1.0.0-0.6.alpha.4.fc35                @updates
libadwaita-doc.noarch                  1.0.0-0.6.alpha.4.fc35                @updates
libadwaita-qt5.x86_64                  1.4.1-3.fc35                          @updates
libadwaita-qt6.x86_64                  1.4.1-3.fc35                          @updates

```