### PR TITLE
container-row: Don't duplicate menu items in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cascade"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18c6a921baae2d947e4cf96f6ef1b5774b3056ae8edbdf5c5cfce4f33260921"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1194,7 @@ dependencies = [
 name = "symphony"
 version = "0.1.0"
 dependencies = [
+ "cascade",
  "futures",
  "gettext-rs",
  "gtk4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 adw = { version = "0.1", package = "libadwaita" }
+cascade = "1"
 futures = { version = "0.3", default-features = false }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.4", package = "gtk4" }

--- a/data/resources/ui/container-row.ui
+++ b/data/resources/ui/container-row.ui
@@ -1,101 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
 
-  <menu id="stopped_menu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Start</attribute>
-        <attribute name="action">container.start</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Commit</attribute>
-        <attribute name="action">container.commit</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Delete</attribute>
-        <attribute name="action">container.delete</attribute>
-      </item>
-    </section>
-  </menu>
-
-  <menu id="running_menu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Stop</attribute>
-        <attribute name="action">container.stop</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Force Stop</attribute>
-        <attribute name="action">container.force-stop</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Restart</attribute>
-        <attribute name="action">container.restart</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">F_orce Restart</attribute>
-        <attribute name="action">container.force-restart</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Pause</attribute>
-        <attribute name="action">container.pause</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Commit</attribute>
-        <attribute name="action">container.commit</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Delete</attribute>
-        <attribute name="action">container.delete</attribute>
-      </item>
-    </section>
-  </menu>
-
-  <menu id="paused_menu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Stop</attribute>
-        <attribute name="action">container.stop</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Force Stop</attribute>
-        <attribute name="action">container.force-stop</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Restart</attribute>
-        <attribute name="action">container.restart</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">F_orce Restart</attribute>
-        <attribute name="action">container.force-restart</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Resume</attribute>
-        <attribute name="action">container.resume</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Commit</attribute>
-        <attribute name="action">container.commit</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Delete</attribute>
-        <attribute name="action">container.delete</attribute>
-      </item>
-    </section>
-  </menu>
-
   <template class="ContainerRow" parent="AdwActionRow">
     <property name="activatable">True</property>
     <property name="action-name">container.show-details</property>
@@ -136,7 +41,6 @@
             <property name="child">
               <object class="GtkMenuButton" id="menu_button">
                 <property name="icon-name">view-more-symbolic</property>
-                <property name="menu-model">stopped_menu</property>
                 <property name="valign">center</property>
               </object>
             </property>


### PR DESCRIPTION
Instead of defining the complete menu for each container state in the ui
file, the menu can also be generated in the code. In this way entire
sections can be reused.